### PR TITLE
chore: use hypebot image v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # instance
+
+Kubernetes manifests for running goingdark.social.
+
+## Hypebot
+
+Hypebot boosts popular posts automatically. It runs `ghcr.io/goingdark-social/hypebot:v0.1.0`.
+Pinning the version keeps the bot predictable; update the tag when you deploy a new release.
+

--- a/hypebot/deploy.yaml
+++ b/hypebot/deploy.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: hype
-          image: ghcr.io/theepicsaxguy/v411e-hype:1.0.0
+          image: ghcr.io/goingdark-social/hypebot:v0.1.0
           env:
             - name: BOT_SERVER
               valueFrom:


### PR DESCRIPTION
## Summary
- update hypebot deployment to use ghcr.io/goingdark-social/hypebot:v0.1.0
- document pinned hypebot image

## Testing
- `kustomize build hypebot`
- `kustomize build .`
- Attempted to install Helm for `helm version`, but download failed with HTTP 403


------
https://chatgpt.com/codex/tasks/task_e_689f98c1e5a883228b27b712fbf1120f