### PR TITLE
feat(mastodon): configure toot and reply limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Kubernetes manifests for running goingdark.social.
 
+## Mastodon
+
+Posts can be up to 1000 characters. Reply fetching waits five minutes after a post is created and then checks every fifteen minutes. It stops after 1000 replies total, 500 per post, or 500 pages so the job doesn't run forever.
+
 ## Hypebot
 
 Hypebot boosts popular posts automatically. It runs `ghcr.io/goingdark-social/hypebot:v0.1.0`.

--- a/mastodon/base/kustomization.yaml
+++ b/mastodon/base/kustomization.yaml
@@ -53,7 +53,13 @@ configMapGenerator:
       - MASTODON_PROMETHEUS_EXPORTER_LOCAL=true
   - name: mastodon-features-env
     literals:
+      - MAX_TOOT_CHARS=1000
       - FETCH_REPLIES_ENABLED=true
+      - FETCH_REPLIES_COOLDOWN_MINUTES=15
+      - FETCH_REPLIES_INITIAL_WAIT_MINUTES=5
+      - FETCH_REPLIES_MAX_GLOBAL=1000
+      - FETCH_REPLIES_MAX_SINGLE=500
+      - FETCH_REPLIES_MAX_PAGES=500
       - IP_RETENTION_PERIOD=15552000
   - name: mastodon-network-env
     literals:


### PR DESCRIPTION
## Summary
- set Mastodon toot length to 1000 characters
- enable reply fetching with cooldown and depth limits
- document Mastodon limits

## Testing
- `kustomize build .`
- `kustomize build mastodon/base`

------
https://chatgpt.com/codex/tasks/task_e_68a5092e31c48322a6c25a7f7f6e4d7d